### PR TITLE
Feature/#21: Twig code fix to output the `field_image` for node teasers

### DIFF
--- a/templates/content/node.html.twig
+++ b/templates/content/node.html.twig
@@ -28,8 +28,8 @@
 <article{{ attributes.addClass(classes)|without('role') }}>
 
   {% if not page and content.field_image is defined %}
-    {% set content = content|without('field_image') %}
     {{ content.field_image }}
+    {% set content = content|without('field_image') %}
   {% endif %}
 
   {{ title_prefix }}


### PR DESCRIPTION
This pull request contains the Twig code fix that will allow to output the `field_image` for node teasers.