### PR TITLE
Bugfix/#27: Removed useless `aria-label` attribute from the `div` layout region container

### DIFF
--- a/includes/preprocess.layout.inc
+++ b/includes/preprocess.layout.inc
@@ -19,8 +19,5 @@ function kiso_preprocess_layout(&$variables) {
     if (!empty(strip_tags(render($variables['content'][$name])))) {
       $variables['visible_region_classes'][] = 'is-visible--' . Html::cleanCssIdentifier($name);
     }
-
-    // Region provides a unique label which can be read by assistive technology.
-    $variables['region_attributes'][$name]['aria-label'] = isset($region_labels[$name]) ? $region_labels[$name] : 'Undefined';
   }
 }


### PR DESCRIPTION
This pull request contains the fix to **remove the preprocessing PHP code** that added an `aria-label` attribute, which should NOT be used on a `div` element unless its given a `role`.