### PR TITLE
Bugfix/#30: Redefines the default `multiple` flag to know if it returns more than 1 item

### DIFF
--- a/templates/field/field.html.twig
+++ b/templates/field/field.html.twig
@@ -8,6 +8,8 @@
  * Custom variables:
  * - label_wrapper: HTML element which wraps the field label according to
  *   its display position (visually_hidden, inline or above).
+ * - multiple: Redefines the default `multiple` flag to know if we have
+ *   more than 1 items to display for the current field result.
  *
  * Related WCAG resources:
  * - SC 1.3.1 Info and Relationships (Level A):
@@ -32,6 +34,7 @@
   ]
 %}
 {% set label_wrapper = label_display == 'above' ? 'h2' : 'div' %}
+{% set multiple = items|length > 1 ? TRUE : FALSE %}
 
 {% if label_hidden %}
   {% if multiple %}


### PR DESCRIPTION
This pull request contains the fix to ensure that multiple-value fields will not use `<ul>` element **when returns 1 item only**.