### PR TITLE
Feature/#41: New `core_version_requirement` key for Drupal 9 compatibility

### DIFF
--- a/kiso.info.yml
+++ b/kiso.info.yml
@@ -5,6 +5,7 @@ type: theme
 base theme: false
 version: '8.x-2.x-dev'
 core: 8.x
+core_version_requirement: ^8 || ^9
 
 # Defines regions
 regions:


### PR DESCRIPTION
This pull request contains the new `core_version_requirement` key (in the `kiso.info.yml` file) which now supports semantic versioning as implemented by the Composer project. This will allow the _Kiso (基礎) base theme_ to also specify that it is **compatible with both the 8 and 9 versions of Drupal core**.