### PR TITLE
Feature/#37: Revert the classes override of the Toolbar core module

### DIFF
--- a/templates/navigation/toolbar.html.twig
+++ b/templates/navigation/toolbar.html.twig
@@ -16,10 +16,10 @@
  */
 #}
 <div{{ attributes.addClass('toolbar') }}>
-  <nav aria-label="{{ toolbar_heading }}"{{ toolbar_attributes.addClass('toolbar__bar', 'clearfix')|without('aria-label', 'role') }}>
+  <nav{{ toolbar_attributes.addClass('toolbar-bar').setAttribute('aria-label', toolbar_heading)|without('role') }}>
     {% for key, tab in tabs %}
       {% set tray = trays[key] %}
-      <div{{ tab.attributes.addClass('toolbar__tab') }}>
+      <div{{ tab.attributes.addClass('toolbar-tab') }}>
         {{ tab.link }}
         {% spaceless %}
           <div{{ tray.attributes }}>

--- a/templates/navigation/toolbar.html.twig
+++ b/templates/navigation/toolbar.html.twig
@@ -23,17 +23,14 @@
         {{ tab.link }}
         {% spaceless %}
           <div{{ tray.attributes }}>
+            {% set tray_wrapper = tray.label ? 'nav' : 'div' %}
             {% if tray.label %}
               <nav class="toolbar-lining clearfix" aria-label="{{ tray.label }}">
             {% else %}
               <div class="toolbar-lining clearfix">
             {% endif %}
             {{ tray.links }}
-            {% if tray.label %}
-              </nav>
-            {% else %}
-              </div>
-            {% endif %}
+            </{{ tray_wrapper }}>
           </div>
         {% endspaceless %}
       </div>


### PR DESCRIPTION
This pull request contains all reverted features regarding the **`CSS` classes naming convention** for the Drupal _Toolbar_ core module.