### PR TITLE
Bugfix/#53: Provide accessible information about unavailable translations for AT users

### DIFF
--- a/includes/preprocess.links.inc
+++ b/includes/preprocess.links.inc
@@ -31,6 +31,8 @@ function kiso_preprocess_links__language_block(&$variables) {
     }
     else {
       $link['title'] = t('@language (unavailable)', ['@language' => $link['text']], ['langcode' => $langcode]);
+      $link['text_attributes']['lang'] = $langcode;
+      $link['text_attributes']['aria-label'] = $link['title'];
       $link['text'] = strtoupper($langcode);
     }
   }

--- a/templates/navigation/links--language-block.html.twig
+++ b/templates/navigation/links--language-block.html.twig
@@ -25,7 +25,7 @@
           {{ item.link }}
         {%- elseif item.text_attributes -%}
           <del{{ item.text_attributes }}>
-            <abbr aria-hidden="true" title="{{ item.title }}">{{ item.text }}</abbr>
+            <abbr title="{{ item.title }}">{{ item.text }}</abbr>
           </del>
         {%- else -%}
           {{ item.text }}


### PR DESCRIPTION
This pull request contains the fix to **provide accessible information** about unavailable translations for both sighted and _Assistive Technology (AT)_ users.