### PR TITLE
Feature/#61: Ensure the image `alt` attribute rendering

### DIFF
--- a/includes/preprocess.image.inc
+++ b/includes/preprocess.image.inc
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * Prepares variables for image (media) templates.
+ */
+
+/**
+ * Implements hook_preprocess_HOOK() for image.html.twig.
+ */
+function kiso_preprocess_image(&$variables) {
+  // WCAG 2.1 - Failure of Success Criterion 1.1.1 due to omitting the `alt`
+  // attribute or text alternative on <img> elements, area elements, and input
+  // elements of type "image":
+  // https://www.w3.org/WAI/WCAG21/Techniques/failures/F65
+  //
+  // If no title attribute is used, and the text alternative is set to null
+  // (i.e. alt="") it indicates to Assistive Technology (AT) that the image is
+  // decorative and can be safely ignored. However, the `alt` attribute MUST
+  // remain mandatory.
+  //
+  // By default, if we mark the "Alt" field as optional in the UI, it will set
+  // the 'alt' variable as NULL which will remove '#alt' property from the image
+  // attributes, resulting in a non-accessible output. The following should fix
+  // this issue.
+  if (!isset($variables['alt']) || is_null($variables['alt'])) {
+    $variables['attributes']['alt'] = '';
+  }
+}

--- a/templates/field/image.html.twig
+++ b/templates/field/image.html.twig
@@ -7,6 +7,7 @@
  * You will find same variables as in the core 'image.html.twig' template.
  *
  * @see template_preprocess_image()
+ * @see kiso_preprocess_image()
  */
 #}
 {%


### PR DESCRIPTION
This pull request contains the fix to ensure that the **image `alt` attribute** will be outputted even if NULL.