### PR TITLE
Bugfix/#72: Restored more relevant `<div>` as wrapper for media items

### DIFF
--- a/templates/content/media.html.twig
+++ b/templates/content/media.html.twig
@@ -5,11 +5,6 @@
  *
  * You will find same variables as in the core 'media.html.twig' template.
  *
- * Related WCAG resources:
- * - SC 1.3.1 Info and Relationships (Level A):
- *   - Wrapping content types (news, document, event...) using the `article`
- *     element.
- *
  * @see template_preprocess_media()
  */
 #}
@@ -23,11 +18,5 @@
 %}
 <div{{ attributes.addClass(classes)|without('role') }}>
   {{ title_suffix.contextual_links }}
-
-  {% if content %}
-    <div{{ content_attributes.addClass('media__content') }}>
-      {{ content }}
-    </div>
-  {% endif %}
-  
+  {{ content }}
 </div>

--- a/templates/content/media.html.twig
+++ b/templates/content/media.html.twig
@@ -21,7 +21,7 @@
     not media.isPublished() ? 'media--unpublished',
   ]
 %}
-<article{{ attributes.addClass(classes)|without('role') }}>
+<div{{ attributes.addClass(classes)|without('role') }}>
   {{ title_suffix.contextual_links }}
 
   {% if content %}
@@ -30,4 +30,4 @@
     </div>
   {% endif %}
   
-</article>
+</div>


### PR DESCRIPTION
This pull request contains the changes that **restore the initial `<div>` element** _(as standing in the core)_ which is more relevant as the `<article>` one for media items.