### PR TITLE
Feature/D8: Added "Splide" accessible slider/carousel TypeScript to libraries

### DIFF
--- a/kiso.libraries.yml
+++ b/kiso.libraries.yml
@@ -197,3 +197,12 @@ track-focus:
       css/base/elements/track-focus.css: {}
   js:
     //cdn.jsdelivr.net/gh/ten1seven/what-input@v5.2.10/dist/what-input.min.js: { type: external, minified: true }
+
+# Splide
+splide:
+  version: v4.1.4
+  header: true
+  css:
+    https://cdn.jsdelivr.net/npm/@splidejs/splide@4.1.4/dist/css/splide.min.css: { type: external, minified: true }
+  js:
+    https://cdn.jsdelivr.net/npm/@splidejs/splide@4.1.4/dist/js/splide.min.js: { type: external, minified: true }

--- a/kiso.libraries.yml
+++ b/kiso.libraries.yml
@@ -200,7 +200,7 @@ track-focus:
 
 # Splide
 splide:
-  version: v4.1.4
+  version: ^4.1
   header: true
   css:
     base:

--- a/kiso.libraries.yml
+++ b/kiso.libraries.yml
@@ -203,6 +203,7 @@ splide:
   version: v4.1.4
   header: true
   css:
-    https://cdn.jsdelivr.net/npm/@splidejs/splide@4.1.4/dist/css/splide.min.css: { type: external, minified: true }
+    base:
+      https://cdn.jsdelivr.net/npm/@splidejs/splide@4.1.4/dist/css/splide.min.css: { type: external, minified: true }
   js:
     https://cdn.jsdelivr.net/npm/@splidejs/splide@4.1.4/dist/js/splide.min.js: { type: external, minified: true }


### PR DESCRIPTION
This pull request relates to [BOSA_0100-219](https://jira.hosted-tools.com/browse/BOSA_0100-219) (JIRA issue) and contains **library updates adding "[Splide](https://splidejs.com/)"** the lightweight, flexible and accessible slider/carousel written in TypeScript.

This pull request will be merged with the `8.2.x-dev` (Drupal 8) branch.