### PR TITLE
Feature/#75: Improved unpublished node styling ensuring high-contrast visibility

### DIFF
--- a/css/components/node/unpublished.css
+++ b/css/components/node/unpublished.css
@@ -1,1 +1,1 @@
-/*! Compiled SASS file | Do NOT modify from here !*/.node--unpublished{background-color:#fef9f9}
+/*! Compiled SASS file | Do NOT modify from here !*/.node--unpublished{padding:0.5rem 1rem;border-width:0.3125rem;border-color:#eb8c95;border-style:solid}

--- a/scss/components/node/unpublished.scss
+++ b/scss/components/node/unpublished.scss
@@ -24,6 +24,11 @@
   // Nodes (Unpublished)
   //
   &--unpublished {
-    @include background($color: lighten(color('red'), 45%));
+    @include rem('padding', map-get($component-vertical-paddings, 'large') map-get($component-horizontal-paddings, 'large'));
+    border: {
+      @include rem('width', ($component-border-width * 5));
+      color: lighten(color('red'), 20%);
+      style: $component-border-style;
+    }
   }
 }


### PR DESCRIPTION
This pull request relates to [BOSA_0100-196](https://jira.hosted-tools.com/browse/BOSA_0100-196) (JIRA issue) and contains **styling updates improving the default Drupal behavior when a node is unpublished** by ensuring high-contrast visibility.