### PR TITLE
Feature/#108: Hosted all resources (fonts, libraries) locally, not from CDN/external hosts

### DIFF
--- a/kiso.libraries.yml
+++ b/kiso.libraries.yml
@@ -9,17 +9,6 @@ normalize:
     base:
       css/base/normalize.css: { weight: -20 }
 
-font-awesome:
-  remote: https://fortawesome.github.io/Font-Awesome/
-  version: 5.13.1
-  license:
-    name: MIT
-    url: https://fontawesome.com/license/free/
-    gpl-compatible: true
-  css:
-    theme:
-      //use.fontawesome.com/releases/v5.13.1/css/all.css: { type: external, minified: true }
-
 # Google Fonts: Open Sans
 font-open-sans:
   remote: https://fonts.google.com/specimen/Open+Sans


### PR DESCRIPTION
This pull request relates to [BOSA_0100-255](https://jira.hosted-tools.com/browse/BOSA_0100-255) (JIRA issue) and makes sure **all resources (fonts, libraries) will be hosted locally**, not from CDN/external hosts.