### PR TITLE
Feature/#113: (Phase 2) Implemented appearance settings to (dis)enable specific default styles for the stylesheets (Baseline)

### DIFF
--- a/config/install/kiso.settings.yml
+++ b/config/install/kiso.settings.yml
@@ -37,3 +37,46 @@ outdatedbrowser_css_exclude: ''
 # JavaScripts / Keyboard Focus Tracking
 trackfocus_enable: 0
 trackfocus_disable_persist: 0
+
+# Structural css rules
+structure_check_all: 1
+reboot_enable: 1
+elements_enable: 1
+elements_options: 1
+elements_selection_enable: 1
+elements_root_enable: 1
+elements_headings_enable: 1
+elements_typography_enable: 1
+elements_blockquotes_enable: 1
+elements_lists_enable: 1
+elements_media_enable: 1
+elements_code_enable: 1
+elements_tables_enable: 1
+elements_forms_enable: 1
+grid_enable: 1
+page_wrapper_enable: 1
+page_section_enable: 1
+header_collapsible_enable: 1
+branding_enable: 1
+breadcrumb_enable: 1
+menu_enable: 1
+menu_menubar_enable: 1
+menu_footer_enable: 1
+action_links_enable: 1
+links_enable: 1
+tabs_enable: 1
+pager_enable: 1
+item_list_enable: 1
+form_button_enable: 1
+form_element_enable: 1
+form_element_label_enable: 1
+form_controls_enable: 1
+form_checks_enable: 1
+inline_labels_enable: 1
+text_formatted_enable: 1
+multiple_value_form_enable: 1
+unpublished_node_enable: 1
+skip_link_enable: 1
+noscript_enable: 1
+messages_enable: 1
+language_block_links_enable: 1

--- a/includes/alter.page-attachments.inc
+++ b/includes/alter.page-attachments.inc
@@ -15,7 +15,8 @@ use Drupal\Component\Utility\Html;
  *
  * @see hook_page_attachments_alter()
  */
-function kiso_page_attachments_alter(array &$attachments) {
+function kiso_page_attachments_alter(array &$attachments)
+{
   $theme_path = \Drupal::theme()->getActiveTheme()->getPath();
 
   // Favicon for iOS - Web Clip.
@@ -202,16 +203,80 @@ function kiso_page_attachments_alter(array &$attachments) {
   }
 
   // Enabling the css depending on the option given in the theme settings
-  // Load the "Base" (Structural rules) libraries.
-  $attachments['#attached']['library'][] = 'kiso/reboot';
-  $attachments['#attached']['library'][] = 'kiso/elements';
+
+  // Load the "Reboot" (Structural rules) libraries.
+  if (theme_get_setting('reboot_enable')) {
+    $attachments['#attached']['library'][] = 'kiso/reboot';
+  }
+  // Load the "Elements" (Styles) library.
+  if (theme_get_setting('elements_enable')) {
+    $attachments['#attached']['library'][] = 'kiso/elements';
+  }
+
   // Load the "Layout" (Styles) library.
-  $attachments['#attached']['library'][] = 'kiso/layout';
+  if (theme_get_setting('layout_enable')) {
+    $attachments['#attached']['library'][] = 'kiso/layout';
+  }
   // Load the "Components" (Structural rules) libraries.
-  $attachments['#attached']['library'][] = 'kiso/blocks';
-  $attachments['#attached']['library'][] = 'kiso/navigations';
-  $attachments['#attached']['library'][] = 'kiso/forms';
-  $attachments['#attached']['library'][] = 'kiso/fields';
-  $attachments['#attached']['library'][] = 'kiso/nodes';
-  $attachments['#attached']['library'][] = 'kiso/miscs';
+  if (theme_get_setting('components_enable')) {
+    $attachments['#attached']['library'][] = 'kiso/blocks';
+    $attachments['#attached']['library'][] = 'kiso/navigations';
+    $attachments['#attached']['library'][] = 'kiso/forms';
+    $attachments['#attached']['library'][] = 'kiso/fields';
+    $attachments['#attached']['library'][] = 'kiso/nodes';
+    $attachments['#attached']['library'][] = 'kiso/miscs';
+  }
+}
+function kiso_css_alter(&$css) {
+  $settings = [
+    // Base elements.
+    'themes/contrib/kiso/css/base/elements/selection.css' => 'elements_selection_enable',
+    'themes/contrib/kiso/css/base/elements/root.css' => 'elements_root_enable',
+    'themes/contrib/kiso/css/base/elements/headings.css' => 'elements_headings_enable',
+    'themes/contrib/kiso/css/base/elements/typography.css' => 'elements_typography_enable',
+    'themes/contrib/kiso/css/base/elements/blockquotes.css' => 'elements_blockquotes_enable',
+    'themes/contrib/kiso/css/base/elements/lists.css' => 'elements_lists_enable',
+    'themes/contrib/kiso/css/base/elements/media.css' => 'elements_media_enable',
+    'themes/contrib/kiso/css/base/elements/code.css' => 'elements_code_enable',
+    'themes/contrib/kiso/css/base/elements/tables.css' => 'elements_tables_enable',
+    'themes/contrib/kiso/css/base/elements/forms.css' => 'elements_forms_enable',
+
+    // Layout.
+    'themes/contrib/kiso/css/layout/grid.css' => 'grid_enable',
+    'themes/contrib/kiso/css/layout/page/wrapper.css' => 'page_wrapper_enable',
+    'themes/contrib/kiso/css/layout/page/section.css' => 'page_section_enable',
+    'themes/contrib/kiso/css/layout/region/header-collapsible.css' => 'header_collapsible_enable',
+
+    // Components.
+    'themes/contrib/kiso/css/components/block/branding.css' => 'branding_enable',
+    'themes/contrib/kiso/css/components/navigation/breadcrumb.css' => 'breadcrumb_enable',
+    'themes/contrib/kiso/css/components/navigation/menu.css' => 'menu_enable',
+    'themes/contrib/kiso/css/components/navigation/menu-menubar.css' => 'menu_menubar_enable',
+    'themes/contrib/kiso/css/components/navigation/menu-footer.css' => 'menu_footer_enable',
+    'themes/contrib/kiso/css/components/navigation/action-links.css' => 'action_links_enable',
+    'themes/contrib/kiso/css/components/navigation/links.css' => 'links_enable',
+    'themes/contrib/kiso/css/components/navigation/tabs.css' => 'tabs_enable',
+    'themes/contrib/kiso/css/components/navigation/pager.css' => 'pager_enable',
+    'themes/contrib/kiso/css/components/dataset/item-list.css' => 'item_list_enable',
+    'themes/contrib/kiso/css/components/form/button.css' => 'form_button_enable',
+    'themes/contrib/kiso/css/components/form/element.css' => 'form_element_enable',
+    'themes/contrib/kiso/css/components/form/element-label.css' => 'form_element_label_enable',
+    'themes/contrib/kiso/css/components/form/controls.css' => 'form_controls_enable',
+    'themes/contrib/kiso/css/components/form/checks.css' => 'form_checks_enable',
+    'themes/contrib/kiso/css/components/field/label-inline.css' => 'inline_labels_enable',
+    'themes/contrib/kiso/css/components/field/text-formatted.css' => 'text_formatted_enable',
+    'themes/contrib/kiso/css/components/field/multiple-value-form.css' => 'multiple_value_form_enable',
+    'themes/contrib/kiso/css/components/field/file.css' => 'file_enable',
+    'themes/contrib/kiso/css/components/node/unpublished.css' => 'unpublished_node_enable',
+    'themes/contrib/kiso/css/components/misc/skip-link.css' => 'skip_link_enable',
+    'themes/contrib/kiso/css/components/misc/noscript.css' => 'noscript_enable',
+    'themes/contrib/kiso/css/components/misc/messages.css' => 'messages_enable',
+    'themes/contrib/kiso/css/components/navigation/links--language-block.css' => 'language_block_links_enable'
+  ];
+
+  foreach ($settings as $css_file => $setting) {
+    if (!theme_get_setting($setting)) {
+      unset($css[$css_file]);
+    }
+  }
 }

--- a/includes/alter.page-attachments.inc
+++ b/includes/alter.page-attachments.inc
@@ -106,19 +106,6 @@ function kiso_page_attachments_alter(array &$attachments) {
     'theme-color',
   );
 
-  // Load the "Base" (Structural rules) libraries.
-  $attachments['#attached']['library'][] = 'kiso/reboot';
-  $attachments['#attached']['library'][] = 'kiso/elements';
-  // Load the "Layout" (Styles) library.
-  $attachments['#attached']['library'][] = 'kiso/layout';
-  // Load the "Components" (Structural rules) libraries.
-  $attachments['#attached']['library'][] = 'kiso/blocks';
-  $attachments['#attached']['library'][] = 'kiso/navigations';
-  $attachments['#attached']['library'][] = 'kiso/forms';
-  $attachments['#attached']['library'][] = 'kiso/fields';
-  $attachments['#attached']['library'][] = 'kiso/nodes';
-  $attachments['#attached']['library'][] = 'kiso/miscs';
-
   // Load the "External Links" (New Window) library.
   $moduleHandler = \Drupal::service('module_handler');
   if ($moduleHandler->moduleExists('extlink') && theme_get_setting('extlinkwindow_enabled')) {
@@ -213,4 +200,18 @@ function kiso_page_attachments_alter(array &$attachments) {
       'speed' => !empty(theme_get_setting('smoothscroll_speed')) ? theme_get_setting('smoothscroll_speed') : $config->get('smoothscroll_speed'),
     ];
   }
+
+  // Enabling the css depending on the option given in the theme settings
+  // Load the "Base" (Structural rules) libraries.
+  $attachments['#attached']['library'][] = 'kiso/reboot';
+  $attachments['#attached']['library'][] = 'kiso/elements';
+  // Load the "Layout" (Styles) library.
+  $attachments['#attached']['library'][] = 'kiso/layout';
+  // Load the "Components" (Structural rules) libraries.
+  $attachments['#attached']['library'][] = 'kiso/blocks';
+  $attachments['#attached']['library'][] = 'kiso/navigations';
+  $attachments['#attached']['library'][] = 'kiso/forms';
+  $attachments['#attached']['library'][] = 'kiso/fields';
+  $attachments['#attached']['library'][] = 'kiso/nodes';
+  $attachments['#attached']['library'][] = 'kiso/miscs';
 }

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -334,20 +334,12 @@ function kiso_form_system_theme_settings_alter(&$form, \Drupal\Core\Form\FormSta
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  $form['style_sheets']['structure_styles']['structure_check_all'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Use all structural styles'),
-    '#default_value' => theme_get_setting('structure_check_all'),
-  );
   // Base styles
   $form['style_sheets']['structure_styles']['base'] = array(
     '#type' => 'details',
     '#title' => t('Base Styles'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
-    '#states' => [
-      'visible' => [':input[name="structure_check_all"]' => ['checked' => FALSE]],
-    ],
   );
   $form['style_sheets']['structure_styles']['base']['reboot'] = array(
     '#type' => 'checkbox',
@@ -367,9 +359,6 @@ function kiso_form_system_theme_settings_alter(&$form, \Drupal\Core\Form\FormSta
     '#description' => t('Enable each structural element css individually.'),
     '#collapsible' => TRUE,
     '#collapsed' => FALSE,
-    '#states' => [
-      'visible' => [':input[name="elements_enable"]' => ['checked' => TRUE]],
-    ],
   );
   $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['selection'] = array(
     '#type' => 'checkbox',
@@ -439,9 +428,6 @@ function kiso_form_system_theme_settings_alter(&$form, \Drupal\Core\Form\FormSta
     '#title' => t('Layout Styles'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
-    '#states' => [
-      'visible' => [':input[name="structure_check_all"]' => ['checked' => FALSE]],
-    ],
   );
   $form['style_sheets']['structure_styles']['layout_styles']['grid'] = array(
     '#type' => 'checkbox',
@@ -473,9 +459,6 @@ function kiso_form_system_theme_settings_alter(&$form, \Drupal\Core\Form\FormSta
     '#title' => t('Component Styles'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
-    '#states' => [
-      'visible' => [':input[name="structure_check_all"]' => ['checked' => FALSE]],
-    ],
   );
   // Component Block styles
   $form['style_sheets']['structure_styles']['component_styles']['blocks'] = array(

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -341,13 +341,13 @@ function kiso_form_system_theme_settings_alter(&$form, \Drupal\Core\Form\FormSta
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  $form['style_sheets']['structure_styles']['base']['reboot'] = array(
+  $form['style_sheets']['structure_styles']['base']['reboot_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable reboot'),
     '#default_value' => theme_get_setting('reboot_enable'),
     '#description' => t("Enable the reboot css."),
   );
-  $form['style_sheets']['structure_styles']['base']['elements']['elements_enable'] = array(
+  $form['style_sheets']['structure_styles']['base']['elements_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable elements'),
     '#default_value' => theme_get_setting('elements_enable'),
@@ -359,64 +359,67 @@ function kiso_form_system_theme_settings_alter(&$form, \Drupal\Core\Form\FormSta
     '#description' => t('Enable each structural element css individually.'),
     '#collapsible' => TRUE,
     '#collapsed' => FALSE,
+    '#states' => [
+      'visible' => [':input[name="elements_enable"]' => ['checked' => TRUE]],
+    ],
   );
-  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['selection'] = array(
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['elements_selection_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable selection'),
     '#default_value' => theme_get_setting('elements_selection_enable'),
     '#description' => t("By checking this you'll enable the css rules for the text selection color."),
   );
   // Base Root
-  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['root'] = array(
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['elements_root_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable root'),
     '#default_value' => theme_get_setting('elements_root_enable'),
     '#description' => t('By checking this, you will enable the CSS rules for the root elements.'),
   );
   // Base Elements
-  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['headings'] = array(
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['elements_headings_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable headings'),
     '#default_value' => theme_get_setting('elements_headings_enable'),
     '#description' => t('By checking this, you will enable the CSS rules for the headings elements.'),
   );
-  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['typography'] = array(
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['elements_typography_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable typography'),
     '#default_value' => theme_get_setting('elements_typography_enable'),
     '#description' => t('By checking this, you will enable the CSS rules for the typography elements.'),
   );
-  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['blockquotes'] = array(
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['elements_blockquotes_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable blockquotes'),
     '#default_value' => theme_get_setting('elements_blockquotes_enable'),
     '#description' => t('By checking this, you will enable the CSS rules for the blockquotes elements.'),
   );
-  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['lists'] = array(
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['elements_lists_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable lists'),
     '#default_value' => theme_get_setting('elements_lists_enable'),
     '#description' => t('By checking this, you will enable the CSS rules for the lists elements.'),
   );
-  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['media'] = array(
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['elements_media_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable media'),
     '#default_value' => theme_get_setting('elements_media_enable'),
     '#description' => t('By checking this, you will enable the CSS rules for the media elements.'),
   );
-  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['code'] = array(
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['elements_code_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable code'),
     '#default_value' => theme_get_setting('elements_code_enable'),
     '#description' => t('By checking this, you will enable the CSS rules for the code elements.'),
   );
-  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['tables'] = array(
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['elements_tables_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable tables'),
     '#default_value' => theme_get_setting('elements_tables_enable'),
     '#description' => t('By checking this, you will enable the CSS rules for the tables elements.'),
   );
-  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['forms'] = array(
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['elements_forms_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable forms'),
     '#default_value' => theme_get_setting('elements_forms_enable'),
@@ -429,25 +432,40 @@ function kiso_form_system_theme_settings_alter(&$form, \Drupal\Core\Form\FormSta
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  $form['style_sheets']['structure_styles']['layout_styles']['grid'] = array(
+  $form['style_sheets']['structure_styles']['layout_styles']['layout_enable'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable layout'),
+    '#default_value' => theme_get_setting('layout_enable'),
+    '#description' => t("Enable the layout css."),
+  );
+  $form['style_sheets']['structure_styles']['layout_styles']['layout_options'] = array(
+    '#type' => 'details',
+    '#title' => t('Layout options'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#states' => [
+      'visible' => [':input[name="layout_enable"]' => ['checked' => TRUE]],
+    ],
+  );
+  $form['style_sheets']['structure_styles']['layout_styles']['layout_options']['grid_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable grid'),
     '#default_value' => theme_get_setting('grid_enable'),
     '#description' => t("Enable the grid css."),
   );
-  $form['style_sheets']['structure_styles']['layout_styles']['page']['wrapper'] = array(
+  $form['style_sheets']['structure_styles']['layout_styles']['layout_options']['page_wrapper_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable page wrapper'),
     '#default_value' => theme_get_setting('page_wrapper_enable'),
     '#description' => t("Enable the page wrapper css."),
   );
-  $form['style_sheets']['structure_styles']['layout_styles']['page']['section'] = array(
+  $form['style_sheets']['structure_styles']['layout_styles']['layout_options']['page_section_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable page section'),
     '#default_value' => theme_get_setting('page_section_enable'),
     '#description' => t("Enable the page section css."),
   );
-  $form['style_sheets']['structure_styles']['layout_styles']['region']['header_collapsible'] = array(
+  $form['style_sheets']['structure_styles']['layout_styles']['layout_options']['header_collapsible_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable collapsible header region'),
     '#default_value' => theme_get_setting('header_collapsible_enable'),
@@ -460,195 +478,223 @@ function kiso_form_system_theme_settings_alter(&$form, \Drupal\Core\Form\FormSta
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
+  $form['style_sheets']['structure_styles']['component_styles']['components_enable'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable components'),
+    '#default_value' => theme_get_setting('components_enable'),
+    '#description' => t("Enable the components css."),
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['component_options'] = array(
+    '#type' => 'details',
+    '#title' => t('Component options'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#states' => [
+      'visible' => [':input[name="components_enable"]' => ['checked' => TRUE]],
+    ],
+  );
   // Component Block styles
-  $form['style_sheets']['structure_styles']['component_styles']['blocks'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['blocks'] = array(
     '#type' => 'details',
     '#title' => t('Block Styles'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  $form['style_sheets']['structure_styles']['component_styles']['blocks']['branding'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['blocks']['branding_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable branding block'),
     '#default_value' => theme_get_setting('branding_enable'),
     '#description' => t("Enable the branding block css."),
   );
   // Components Navigation Styles
-  $form['style_sheets']['structure_styles']['component_styles']['navigations'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['navigations'] = array(
     '#type' => 'details',
     '#title' => t('Navigation Styles'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  $form['style_sheets']['structure_styles']['component_styles']['navigations']['breadcrumb'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['navigations']['breadcrumb_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable breadcrumb'),
     '#default_value' => theme_get_setting('breadcrumb_enable'),
     '#description' => t("Enable the breadcrumb css."),
   );
-  $form['style_sheets']['structure_styles']['component_styles']['navigations']['menu'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['navigations']['menu_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable menu'),
     '#default_value' => theme_get_setting('menu_enable'),
     '#description' => t("Enable the menu css."),
   );
-  $form['style_sheets']['structure_styles']['component_styles']['navigations']['menu_menubar'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['navigations']['menu_menubar_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable menu menubar'),
     '#default_value' => theme_get_setting('menu_menubar_enable'),
     '#description' => t("Enable the menu menubar css."),
   );
-  $form['style_sheets']['structure_styles']['component_styles']['navigations']['menu_footer'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['navigations']['menu_footer_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable menu footer'),
     '#default_value' => theme_get_setting('menu_footer_enable'),
     '#description' => t("Enable the menu footer css."),
   );
-  $form['style_sheets']['structure_styles']['component_styles']['navigations']['action_links'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['navigations']['action_links_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable action links'),
     '#default_value' => theme_get_setting('action_links_enable'),
     '#description' => t("Enable the action links css."),
   );
-  $form['style_sheets']['structure_styles']['component_styles']['navigations']['links'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['navigations']['links_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable links'),
     '#default_value' => theme_get_setting('links_enable'),
     '#description' => t("Enable the links css."),
   );
-  $form['style_sheets']['structure_styles']['component_styles']['navigations']['tabs'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['navigations']['tabs_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable tabs'),
     '#default_value' => theme_get_setting('tabs_enable'),
     '#description' => t("Enable the tabs css."),
   );
-  $form['style_sheets']['structure_styles']['component_styles']['navigations']['pager'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['navigations']['pager_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable pager'),
     '#default_value' => theme_get_setting('pager_enable'),
     '#description' => t("Enable the pager css."),
   );
-  $form['style_sheets']['structure_styles']['component_styles']['navigations']['item_list'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['navigations']['item_list_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable item list'),
     '#default_value' => theme_get_setting('item_list_enable'),
     '#description' => t("Enable the item list css."),
   );
   // Component Form Styles
-  $form['style_sheets']['structure_styles']['component_styles']['forms'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['forms'] = array(
     '#type' => 'details',
     '#title' => t('Form Styles'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  $form['style_sheets']['structure_styles']['component_styles']['forms']['button'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['forms']['form_button_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable form button'),
     '#default_value' => theme_get_setting('form_button_enable'),
     '#description' => t("Enable the form button css."),
   );
-  $form['style_sheets']['structure_styles']['component_styles']['forms']['element'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['forms']['form_element_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable form element'),
     '#default_value' => theme_get_setting('form_element_enable'),
     '#description' => t("Enable the form element css."),
   );
-  $form['style_sheets']['structure_styles']['component_styles']['forms']['element_label'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['forms']['form_element_label_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable form element label'),
     '#default_value' => theme_get_setting('form_element_label_enable'),
     '#description' => t("Enable the form element label css."),
   );
-  $form['style_sheets']['structure_styles']['component_styles']['forms']['controls'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['forms']['form_controls_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable form controls'),
     '#default_value' => theme_get_setting('form_controls_enable'),
     '#description' => t("Enable the form controls css."),
   );
-  $form['style_sheets']['structure_styles']['component_styles']['forms']['checks'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['forms']['form_checks_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable form checks'),
     '#default_value' => theme_get_setting('form_checks_enable'),
     '#description' => t("Enable the form checks css."),
   );
   // Component Field Styles
-  $form['style_sheets']['structure_styles']['component_styles']['fields'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['file'] = array(
+    '#type' => 'details',
+    '#title' => t('File Styles'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['file']['file_enable'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable file styles'),
+    '#default_value' => theme_get_setting('file_enable'),
+    '#description' => t("Enable the file css."),
+  );
+  // Component Field Styles
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['fields'] = array(
     '#type' => 'details',
     '#title' => t('Field Styles'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  $form['style_sheets']['structure_styles']['component_styles']['fields']['label_inline'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['fields']['inline_labels_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable inline labels'),
     '#default_value' => theme_get_setting('inline_labels_enable'),
     '#description' => t("Enable the inline labels css."),
   );
-  $form['style_sheets']['structure_styles']['component_styles']['fields']['text_formatted'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['fields']['text_formatted_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable text formatted'),
     '#default_value' => theme_get_setting('text_formatted_enable'),
     '#description' => t("Enable the text formatted css."),
   );
-  $form['style_sheets']['structure_styles']['component_styles']['fields']['multiple_value_form'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['fields']['multiple_value_form_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable multiple value form'),
     '#default_value' => theme_get_setting('multiple_value_form_enable'),
     '#description' => t("Enable the multiple value form css."),
   );
-  $form['style_sheets']['structure_styles']['component_styles']['nodes'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['nodes'] = array(
     '#type' => 'details',
     '#title' => t('Node Styles'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
   // Component Nodes Styles
-  $form['style_sheets']['structure_styles']['component_styles']['nodes']['unpublished'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['nodes']['unpublished_node_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable unpublished node'),
     '#default_value' => theme_get_setting('unpublished_node_enable'),
     '#description' => t("Enable the unpublished node css."),
   );
   // Component Miscs Styles
-  $form['style_sheets']['structure_styles']['component_styles']['miscs'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['miscs'] = array(
     '#type' => 'details',
     '#title' => t('Miscellaneous Styles'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  $form['style_sheets']['structure_styles']['component_styles']['miscs']['skip_link'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['miscs']['skip_link_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable skip link'),
     '#default_value' => theme_get_setting('skip_link_enable'),
     '#description' => t("Enable the skip link css"),
   );
-  $form['style_sheets']['structure_styles']['component_styles']['miscs']['noscript'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['miscs']['noscript_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable noscript'),
     '#default_value' => theme_get_setting('noscript_enable'),
     '#description' => t("Enable the noscript css."),
   );
   // Component Messages Styles
-  $form['style_sheets']['structure_styles']['component_styles']['messages'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['messages'] = array(
     '#type' => 'details',
     '#title' => t('Message Styles'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  $form['style_sheets']['structure_styles']['component_styles']['messages']['messages'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['messages']['messages_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable messages'),
     '#default_value' => theme_get_setting('messages_enable'),
     '#description' => t("Enable the messages css."),
   );
   // Component Language block Styles
-  $form['style_sheets']['structure_styles']['component_styles']['links--language-block'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['links--language-block'] = array(
     '#type' => 'details',
     '#title' => t('Language Block Links Styles'),
     '#collapsible' => TRUE,
     '#collapsed' => TRUE,
   );
-  $form['style_sheets']['structure_styles']['component_styles']['links--language-block']['links--language-block'] = array(
+  $form['style_sheets']['structure_styles']['component_styles']['component_options']['links--language-block']['language_block_links_enable'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable language block links'),
     '#default_value' => theme_get_setting('language_block_links_enable'),

--- a/theme-settings.php
+++ b/theme-settings.php
@@ -24,7 +24,8 @@ use Drupal\Core\Messenger;
  * @param $form_state
  *   The current state of the form.
  */
-function kiso_form_system_theme_settings_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state) {
+function kiso_form_system_theme_settings_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state)
+{
 
   $form['kiso_settings'] = array(
     '#type' => 'vertical_tabs',
@@ -320,6 +321,355 @@ function kiso_form_system_theme_settings_alter(&$form, \Drupal\Core\Form\FormSta
     '#title' => t('Hide on mobile'),
     '#default_value' => theme_get_setting('backtotop_mobile_hide'),
     '#description' => t("By checking this box, the back to top link won't appear on smaller devices according to the site's responsive breakpoints."),
+  );
+  // Style sheets
+  $form['style_sheets'] = array(
+    '#type' => 'details',
+    '#title' => t('Style Sheets'),
+    '#group' => 'kiso_settings',
+  );
+  $form['style_sheets']['structure_styles'] = array(
+    '#type' => 'details',
+    '#title' => t('Structure Styles'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['style_sheets']['structure_styles']['structure_check_all'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Use all structural styles'),
+    '#default_value' => theme_get_setting('structure_check_all'),
+  );
+  // Base styles
+  $form['style_sheets']['structure_styles']['base'] = array(
+    '#type' => 'details',
+    '#title' => t('Base Styles'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#states' => [
+      'visible' => [':input[name="structure_check_all"]' => ['checked' => FALSE]],
+    ],
+  );
+  $form['style_sheets']['structure_styles']['base']['reboot'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable reboot'),
+    '#default_value' => theme_get_setting('reboot_enable'),
+    '#description' => t("Enable the reboot css."),
+  );
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_enable'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable elements'),
+    '#default_value' => theme_get_setting('elements_enable'),
+    '#description' => t("Enable the elements css."),
+  );
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options'] = array(
+    '#type' => 'details',
+    '#title' => t('Elements options'),
+    '#description' => t('Enable each structural element css individually.'),
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE,
+    '#states' => [
+      'visible' => [':input[name="elements_enable"]' => ['checked' => TRUE]],
+    ],
+  );
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['selection'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable selection'),
+    '#default_value' => theme_get_setting('elements_selection_enable'),
+    '#description' => t("By checking this you'll enable the css rules for the text selection color."),
+  );
+  // Base Root
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['root'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable root'),
+    '#default_value' => theme_get_setting('elements_root_enable'),
+    '#description' => t('By checking this, you will enable the CSS rules for the root elements.'),
+  );
+  // Base Elements
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['headings'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable headings'),
+    '#default_value' => theme_get_setting('elements_headings_enable'),
+    '#description' => t('By checking this, you will enable the CSS rules for the headings elements.'),
+  );
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['typography'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable typography'),
+    '#default_value' => theme_get_setting('elements_typography_enable'),
+    '#description' => t('By checking this, you will enable the CSS rules for the typography elements.'),
+  );
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['blockquotes'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable blockquotes'),
+    '#default_value' => theme_get_setting('elements_blockquotes_enable'),
+    '#description' => t('By checking this, you will enable the CSS rules for the blockquotes elements.'),
+  );
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['lists'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable lists'),
+    '#default_value' => theme_get_setting('elements_lists_enable'),
+    '#description' => t('By checking this, you will enable the CSS rules for the lists elements.'),
+  );
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['media'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable media'),
+    '#default_value' => theme_get_setting('elements_media_enable'),
+    '#description' => t('By checking this, you will enable the CSS rules for the media elements.'),
+  );
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['code'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable code'),
+    '#default_value' => theme_get_setting('elements_code_enable'),
+    '#description' => t('By checking this, you will enable the CSS rules for the code elements.'),
+  );
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['tables'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable tables'),
+    '#default_value' => theme_get_setting('elements_tables_enable'),
+    '#description' => t('By checking this, you will enable the CSS rules for the tables elements.'),
+  );
+  $form['style_sheets']['structure_styles']['base']['elements']['elements_options']['forms'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable forms'),
+    '#default_value' => theme_get_setting('elements_forms_enable'),
+    '#description' => t('By checking this, you will enable the CSS rules for the forms elements.'),
+  );
+  // Layout styles
+  $form['style_sheets']['structure_styles']['layout_styles'] = array(
+    '#type' => 'details',
+    '#title' => t('Layout Styles'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#states' => [
+      'visible' => [':input[name="structure_check_all"]' => ['checked' => FALSE]],
+    ],
+  );
+  $form['style_sheets']['structure_styles']['layout_styles']['grid'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable grid'),
+    '#default_value' => theme_get_setting('grid_enable'),
+    '#description' => t("Enable the grid css."),
+  );
+  $form['style_sheets']['structure_styles']['layout_styles']['page']['wrapper'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable page wrapper'),
+    '#default_value' => theme_get_setting('page_wrapper_enable'),
+    '#description' => t("Enable the page wrapper css."),
+  );
+  $form['style_sheets']['structure_styles']['layout_styles']['page']['section'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable page section'),
+    '#default_value' => theme_get_setting('page_section_enable'),
+    '#description' => t("Enable the page section css."),
+  );
+  $form['style_sheets']['structure_styles']['layout_styles']['region']['header_collapsible'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable collapsible header region'),
+    '#default_value' => theme_get_setting('header_collapsible_enable'),
+    '#description' => t("Enable the collapsible header region css."),
+  );
+  // Component Styles
+  $form['style_sheets']['structure_styles']['component_styles'] = array(
+    '#type' => 'details',
+    '#title' => t('Component Styles'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+    '#states' => [
+      'visible' => [':input[name="structure_check_all"]' => ['checked' => FALSE]],
+    ],
+  );
+  // Component Block styles
+  $form['style_sheets']['structure_styles']['component_styles']['blocks'] = array(
+    '#type' => 'details',
+    '#title' => t('Block Styles'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['blocks']['branding'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable branding block'),
+    '#default_value' => theme_get_setting('branding_enable'),
+    '#description' => t("Enable the branding block css."),
+  );
+  // Components Navigation Styles
+  $form['style_sheets']['structure_styles']['component_styles']['navigations'] = array(
+    '#type' => 'details',
+    '#title' => t('Navigation Styles'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['navigations']['breadcrumb'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable breadcrumb'),
+    '#default_value' => theme_get_setting('breadcrumb_enable'),
+    '#description' => t("Enable the breadcrumb css."),
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['navigations']['menu'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable menu'),
+    '#default_value' => theme_get_setting('menu_enable'),
+    '#description' => t("Enable the menu css."),
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['navigations']['menu_menubar'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable menu menubar'),
+    '#default_value' => theme_get_setting('menu_menubar_enable'),
+    '#description' => t("Enable the menu menubar css."),
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['navigations']['menu_footer'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable menu footer'),
+    '#default_value' => theme_get_setting('menu_footer_enable'),
+    '#description' => t("Enable the menu footer css."),
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['navigations']['action_links'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable action links'),
+    '#default_value' => theme_get_setting('action_links_enable'),
+    '#description' => t("Enable the action links css."),
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['navigations']['links'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable links'),
+    '#default_value' => theme_get_setting('links_enable'),
+    '#description' => t("Enable the links css."),
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['navigations']['tabs'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable tabs'),
+    '#default_value' => theme_get_setting('tabs_enable'),
+    '#description' => t("Enable the tabs css."),
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['navigations']['pager'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable pager'),
+    '#default_value' => theme_get_setting('pager_enable'),
+    '#description' => t("Enable the pager css."),
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['navigations']['item_list'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable item list'),
+    '#default_value' => theme_get_setting('item_list_enable'),
+    '#description' => t("Enable the item list css."),
+  );
+  // Component Form Styles
+  $form['style_sheets']['structure_styles']['component_styles']['forms'] = array(
+    '#type' => 'details',
+    '#title' => t('Form Styles'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['forms']['button'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable form button'),
+    '#default_value' => theme_get_setting('form_button_enable'),
+    '#description' => t("Enable the form button css."),
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['forms']['element'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable form element'),
+    '#default_value' => theme_get_setting('form_element_enable'),
+    '#description' => t("Enable the form element css."),
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['forms']['element_label'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable form element label'),
+    '#default_value' => theme_get_setting('form_element_label_enable'),
+    '#description' => t("Enable the form element label css."),
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['forms']['controls'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable form controls'),
+    '#default_value' => theme_get_setting('form_controls_enable'),
+    '#description' => t("Enable the form controls css."),
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['forms']['checks'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable form checks'),
+    '#default_value' => theme_get_setting('form_checks_enable'),
+    '#description' => t("Enable the form checks css."),
+  );
+  // Component Field Styles
+  $form['style_sheets']['structure_styles']['component_styles']['fields'] = array(
+    '#type' => 'details',
+    '#title' => t('Field Styles'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['fields']['label_inline'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable inline labels'),
+    '#default_value' => theme_get_setting('inline_labels_enable'),
+    '#description' => t("Enable the inline labels css."),
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['fields']['text_formatted'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable text formatted'),
+    '#default_value' => theme_get_setting('text_formatted_enable'),
+    '#description' => t("Enable the text formatted css."),
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['fields']['multiple_value_form'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable multiple value form'),
+    '#default_value' => theme_get_setting('multiple_value_form_enable'),
+    '#description' => t("Enable the multiple value form css."),
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['nodes'] = array(
+    '#type' => 'details',
+    '#title' => t('Node Styles'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  // Component Nodes Styles
+  $form['style_sheets']['structure_styles']['component_styles']['nodes']['unpublished'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable unpublished node'),
+    '#default_value' => theme_get_setting('unpublished_node_enable'),
+    '#description' => t("Enable the unpublished node css."),
+  );
+  // Component Miscs Styles
+  $form['style_sheets']['structure_styles']['component_styles']['miscs'] = array(
+    '#type' => 'details',
+    '#title' => t('Miscellaneous Styles'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['miscs']['skip_link'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable skip link'),
+    '#default_value' => theme_get_setting('skip_link_enable'),
+    '#description' => t("Enable the skip link css"),
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['miscs']['noscript'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable noscript'),
+    '#default_value' => theme_get_setting('noscript_enable'),
+    '#description' => t("Enable the noscript css."),
+  );
+  // Component Messages Styles
+  $form['style_sheets']['structure_styles']['component_styles']['messages'] = array(
+    '#type' => 'details',
+    '#title' => t('Message Styles'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['messages']['messages'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable messages'),
+    '#default_value' => theme_get_setting('messages_enable'),
+    '#description' => t("Enable the messages css."),
+  );
+  // Component Language block Styles
+  $form['style_sheets']['structure_styles']['component_styles']['links--language-block'] = array(
+    '#type' => 'details',
+    '#title' => t('Language Block Links Styles'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+  $form['style_sheets']['structure_styles']['component_styles']['links--language-block']['links--language-block'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable language block links'),
+    '#default_value' => theme_get_setting('language_block_links_enable'),
+    '#description' => t("Enable the language block links css."),
   );
 
   // Display a warning if the "External Links" module is not enabled.


### PR DESCRIPTION
This pull request relates to [BRFRONTEND#4](https://bridge.hosted-tools.com/contract/95589) (BRIDGE contract) and concerns the stylesheets (Baseline) reshuffling (Phase 2) ensuring to **implement appearance settings**, that will allow front-end developers to (dis)enable specific base, component or theme default styles their sub-theme could inherit from the **_Drupal Kiso (基礎)_** base theme.