### PR TITLE
Bugfix/#64: Replace old implementation to check empty regions with contrib module…

### DIFF
--- a/includes/preprocess.html.inc
+++ b/includes/preprocess.html.inc
@@ -9,25 +9,6 @@
  * Implements hook_preprocess_HOOK() for html.html.twig.
  */
 function kiso_preprocess_html(&$variables) {
-  // Added body classes when sidebar(s) has (have) content.
-  if (_kiso_has_region(\Drupal::service('renderer')->render($variables['page']['navigation'])) && _kiso_has_region(\Drupal::service('renderer')->render($variables['page']['complementary']))) {
-    $variables['attributes']['class'][] = 'sidebar';
-    $variables['attributes']['class'][] = 'two-sidebars';
-  }
-  elseif (_kiso_has_region(\Drupal::service('renderer')->render($variables['page']['navigation']))) {
-    $variables['attributes']['class'][] = 'sidebar';
-    $variables['attributes']['class'][] = 'one-sidebar';
-    $variables['attributes']['class'][] = 'is-visible--navigation';
-  }
-  elseif (_kiso_has_region(\Drupal::service('renderer')->render($variables['page']['complementary']))) {
-    $variables['attributes']['class'][] = 'sidebar';
-    $variables['attributes']['class'][] = 'one-sidebar';
-    $variables['attributes']['class'][] = 'is-visible--complementary';
-  }
-  else {
-    $variables['attributes']['class'][] = 'no-sidebars';
-  }
-
   // Add body classes related to node content.
   $node = \Drupal::routeMatch()->getParameter('node');
   if ($node) {

--- a/includes/preprocess.page.inc
+++ b/includes/preprocess.page.inc
@@ -9,13 +9,6 @@
  * Implements hook_preprocess_HOOK() for page.html.twig.
  */
 function kiso_preprocess_page(&$variables) {
-  // Add boolean variables detecting if regions are empty.
-  $theme = \Drupal::theme()->getActiveTheme()->getName();
-  $regions = system_region_list($theme);
-  foreach ($regions as $key => $value) {
-    $variables['has_' . $key] = _kiso_has_region(\Drupal::service('renderer')->render($variables['page'][$key]));
-  }
-
   // Create variable for status code.
   if ($exception = \Drupal::request()->get('exception')) {
     $status_code = $exception->getStatusCode();

--- a/includes/preprocess.utils.inc
+++ b/includes/preprocess.utils.inc
@@ -6,26 +6,6 @@
  */
 
 /**
- * Properly detect if regions are empty.
- *
- * @param ?string $markup
- *   The rendered region markup to be tested if empty.
- * @param string $allowed_tags
- *   Allowed tags to be excluded from the strip HTML tags process.
- *
- * @return
- *   TRUE if the region exists and is not empty, FALSE otherwise.
- *
- * @see https://www.drupal.org/node/953034
- * @see https://drupal.stackexchange.com/questions/175389/how-do-i-properly-detect-if-region-is-empty
- */
-function _kiso_has_region(?string $markup, string $allowed_tags = '') {
-  $non_conditional_html_comments_pattern = '/<!--(.|\s)*?-->\s*|\r|\n/';
-  $cleaned_region_output = preg_replace($non_conditional_html_comments_pattern, '', $markup);
-  return !empty(_kiso_strip_tags($cleaned_region_output, $allowed_tags));
-}
-
-/**
  * Strips html tags, except allowed, returning a trimmed clean markup.
  */
 function _kiso_strip_tags(string $markup, string $allowed_tags = '') {

--- a/kiso.info.yml
+++ b/kiso.info.yml
@@ -58,3 +58,7 @@ libraries-override:
     css:
       theme:
         extlink.css: 'css/components/extlink/extlink-window.css'
+
+# Defines module dependencies
+dependencies:
+  - drupal:twig_real_content

--- a/templates/layout/html.html.twig
+++ b/templates/layout/html.html.twig
@@ -27,6 +27,17 @@
     db_offline ? 'db-offline',
   ]
 %}
+{% set page_navigaton = page.navigation|render %}
+{% set page_complementary = page.complementary|render %}
+{% if page_navigation is real_content and page_complementary is real_content %}
+  {% set body_classes = body_classes|merge(['sidebar', 'two-sidebars']) %}
+{% elseif page_navigaton is real_content %}
+  {% set body_classes = body_classes|merge(['sidebar', 'one-sidebar', 'is-visible--navigation']) %}
+{% elseif page_complementary is real_content %}
+  {% set body_classes = body_classes|merge(['sidebar', 'one-sidebar', 'is-visible--complementary']) %}
+{% else %}
+  {% set body_classes = body_classes|merge(['no-sidebars']) %}
+{% endif %}
 {# Enable the "Back to top" button. #}
 {% if backtotop_enable %}
   {% set attributes = attributes.setAttribute('id', 'top') %}

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -7,10 +7,6 @@
  * can be found in the 'html.html.twig' template in this directory.
  *
  * You will find same variables as in the core 'page.html.twig' template.
- * 
- * Custom variables:
- * - has_tools, has_header, has_header_collapsible, has_highlighted, has_navigation,
- *   has_complementary, has_postscript, has_footer: Properly detect if regions are empty.
  *
  * Regions:
  * - page.tools: Items for the Toolbar region.
@@ -40,7 +36,7 @@
 {% set container = container_fluid ? 'container-fluid' : 'container' %}
 
 {# Toolbar Area #}
-{% if has_tools %}
+{% if page.tools|render is real_content %}
   {% block tools %}
     <div class="page__wrapper page__wrapper--tools">
       <div class="page__section page__section--tools {{ container }}">
@@ -51,7 +47,7 @@
 {% endif %}
 
 {# Banner Landmark #}
-{% if has_header or has_header_collapsible %}
+{% if page.header|render is real_content or page.header_collapsible|render is real_content %}
   {% block header %}
     <div class="page__wrapper page__wrapper--header">
       <header class="page__section page__section--header {{ container }}">
@@ -65,7 +61,7 @@
 {% endif %}
 
 {# Featured content Area #}
-{% if has_highlighted %}
+{% if page.highlighted|render is real_content %}
   {% block highlighted %}
     <div class="page__wrapper page__wrapper--highlighted">
       <div class="page__section page__section--highlighted {{ container }}">
@@ -89,7 +85,7 @@
       {{ page.breadcrumb }}
     {% endblock %}
 
-    {% if has_navigation or has_complementary %}
+    {% if page.navigation|render is real_content or page.complementary|render is real_content %}
       <div class="{{ container }}">
         <div class="row">
     {% endif %}
@@ -99,7 +95,7 @@
         set content_classes = [
           'page__section',
           'page__section--content',
-          has_navigation or has_complementary ? '' : container,
+          page.navigation|render is real_content or page.complementary|render is real_content ? '' : container,
         ]
       %}
       {% block content %}
@@ -114,7 +110,7 @@
       {% endblock %}
 
       {# Navigation sidebar (Left) #}
-      {% if has_navigation %}
+      {% if page.navigation|render is real_content %}
         {% block navigation %}
           <div class="page__section page__section--navigation">
             {{ page.navigation }}
@@ -123,7 +119,7 @@
       {% endif %}
 
       {# Related content sidebar (Right) #}
-      {% if has_complementary %}
+      {% if page.complementary|render is real_content %}
         {% block complementary %}
           <div class="page__section page__section--complementary">
             {{ page.complementary }}
@@ -131,7 +127,7 @@
         {% endblock %}
       {% endif %}
 
-    {% if has_navigation or has_complementary %}
+    {% if page.navigation|render is real_content or page.complementary|render is real_content %}
         </div>
       </div>
     {% endif %}
@@ -140,7 +136,7 @@
 {% endblock %}
 
 {# Footnotes Area #}
-{% if has_postscript %}
+{% if page.postscript|render is real_content %}
   {% block postscript %}
     <div class="page__wrapper page__wrapper--postscript">
       <div class="page__section page__section--postscript {{ container }}">
@@ -151,7 +147,7 @@
 {% endif %}
 
 {# Contentinfo Landmark #}
-{% if has_footer %}
+{% if page.footer|render is real_content %}
   {% block footer %}
     <div class="page__wrapper page__wrapper--footer">
       <footer class="page__section page__section--footer {{ container }}">


### PR DESCRIPTION
This pull request relates to [BOSA_0100-358](https://jira.hosted-tools.com/browse/BOSA_0100-358) (JIRA issue) and replaces old implementation to check empty regions with contrib module "Twig Real Content".

Module "[Twig Real Content](https://www.drupal.org/project/twig_real_content)" should also be added in OpenFed as declaring in Kiso's dependencies currently doesn't trigger the installation and doesn't enable the module (see https://www.drupal.org/node/2937955).

Function "has_region" declared in file "preprocess.utils.inc" might need to be kept currently to avoid issue with custom themes that override page.html.twig. What do you think @smillart ?