### PR TITLE
Feature/#99: Add unique ID to form

### DIFF
--- a/includes/alter.form.inc
+++ b/includes/alter.form.inc
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @file
+ * Perform alterations before a form is rendered.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_alter().
+ */
+function kiso_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Add unique ID to forms.
+  $form['#id'] = Html::getUniqueId($form['#id']);
+}

--- a/kiso.theme
+++ b/kiso.theme
@@ -16,6 +16,7 @@
  */
 
 // Include and evaluate [pre]process and hook functions from the `./includes` directory.
+include_once "includes/alter.form.inc";
 include_once "includes/alter.page-attachments.inc";
 include_once "includes/alter.theme-suggestions.inc";
 include_once "includes/preprocess.block.inc";


### PR DESCRIPTION
This pull request relates to [BOSA_0100-332](https://jira.hosted-tools.com/browse/BOSA_0100-332) (JIRA issue) and **alters forms** (like search box placed twice on the page) making sure we have **unique IDs**.

Previous PR has been closed and replaced with this one. Comments from PR #119 has been taken into account.