### PR TITLE
Bugfix/#64: Empty regions verification optimization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         }
     },
     "require": {
-        "drupal/core": "^9 || ^10"
+        "drupal/core": "^9 || ^10",
+        "drupal/twig_real_content": "^1.0"
     },
     "require-dev": {},
     "minimum-stability": "dev",

--- a/includes/preprocess.html.inc
+++ b/includes/preprocess.html.inc
@@ -9,6 +9,25 @@
  * Implements hook_preprocess_HOOK() for html.html.twig.
  */
 function kiso_preprocess_html(&$variables) {
+  // Added body classes when sidebar(s) has (have) content.
+  if (_kiso_has_region(\Drupal::service('renderer')->render($variables['page']['navigation'])) && _kiso_has_region(\Drupal::service('renderer')->render($variables['page']['complementary']))) {
+    $variables['attributes']['class'][] = 'sidebar';
+    $variables['attributes']['class'][] = 'two-sidebars';
+  }
+  elseif (_kiso_has_region(\Drupal::service('renderer')->render($variables['page']['navigation']))) {
+    $variables['attributes']['class'][] = 'sidebar';
+    $variables['attributes']['class'][] = 'one-sidebar';
+    $variables['attributes']['class'][] = 'is-visible--navigation';
+  }
+  elseif (_kiso_has_region(\Drupal::service('renderer')->render($variables['page']['complementary']))) {
+    $variables['attributes']['class'][] = 'sidebar';
+    $variables['attributes']['class'][] = 'one-sidebar';
+    $variables['attributes']['class'][] = 'is-visible--complementary';
+  }
+  else {
+    $variables['attributes']['class'][] = 'no-sidebars';
+  }
+
   // Add body classes related to node content.
   $node = \Drupal::routeMatch()->getParameter('node');
   if ($node) {

--- a/includes/preprocess.html.inc
+++ b/includes/preprocess.html.inc
@@ -9,17 +9,24 @@
  * Implements hook_preprocess_HOOK() for html.html.twig.
  */
 function kiso_preprocess_html(&$variables) {
+
+  $variables['page_tools'] = _kiso_render_region($variables['page']['tools']);
+  $variables['page_navigation'] = _kiso_render_region($variables['page']['navigation']);
+  $variables['page_complementary'] = _kiso_render_region($variables['page']['complementary']);
+  $has_navigation = _kiso_has_region($variables['page_navigation']);
+  $has_complementary = _kiso_has_region($variables['page_complementary']);
+
   // Added body classes when sidebar(s) has (have) content.
-  if (_kiso_has_region(\Drupal::service('renderer')->render($variables['page']['navigation'])) && _kiso_has_region(\Drupal::service('renderer')->render($variables['page']['complementary']))) {
+  if ($has_navigation && $has_complementary) {
     $variables['attributes']['class'][] = 'sidebar';
     $variables['attributes']['class'][] = 'two-sidebars';
   }
-  elseif (_kiso_has_region(\Drupal::service('renderer')->render($variables['page']['navigation']))) {
+  elseif ($has_navigation) {
     $variables['attributes']['class'][] = 'sidebar';
     $variables['attributes']['class'][] = 'one-sidebar';
     $variables['attributes']['class'][] = 'is-visible--navigation';
   }
-  elseif (_kiso_has_region(\Drupal::service('renderer')->render($variables['page']['complementary']))) {
+  elseif ($has_complementary) {
     $variables['attributes']['class'][] = 'sidebar';
     $variables['attributes']['class'][] = 'one-sidebar';
     $variables['attributes']['class'][] = 'is-visible--complementary';

--- a/includes/preprocess.html.inc
+++ b/includes/preprocess.html.inc
@@ -10,7 +10,6 @@
  */
 function kiso_preprocess_html(&$variables) {
 
-  $variables['page_tools'] = _kiso_render_region($variables['page']['tools']);
   $variables['page_navigation'] = _kiso_render_region($variables['page']['navigation']);
   $variables['page_complementary'] = _kiso_render_region($variables['page']['complementary']);
   $has_navigation = _kiso_has_region($variables['page_navigation']);

--- a/includes/preprocess.page.inc
+++ b/includes/preprocess.page.inc
@@ -13,7 +13,8 @@ function kiso_preprocess_page(&$variables) {
   $theme = \Drupal::theme()->getActiveTheme()->getName();
   $regions = system_region_list($theme);
   foreach ($regions as $key => $value) {
-    $variables['has_' . $key] = _kiso_has_region(\Drupal::service('renderer')->render($variables['page'][$key]));
+    $variables['page_'. $key] = _kiso_render_region($variables['page'][$key]);
+    $variables['has_' . $key] = _kiso_has_region($variables['page_'. $key]);
   }
 
   // Create variable for status code.

--- a/includes/preprocess.page.inc
+++ b/includes/preprocess.page.inc
@@ -9,6 +9,13 @@
  * Implements hook_preprocess_HOOK() for page.html.twig.
  */
 function kiso_preprocess_page(&$variables) {
+  // Add boolean variables detecting if regions are empty.
+  $theme = \Drupal::theme()->getActiveTheme()->getName();
+  $regions = system_region_list($theme);
+  foreach ($regions as $key => $value) {
+    $variables['has_' . $key] = _kiso_has_region(\Drupal::service('renderer')->render($variables['page'][$key]));
+  }
+
   // Create variable for status code.
   if ($exception = \Drupal::request()->get('exception')) {
     $status_code = $exception->getStatusCode();

--- a/includes/preprocess.utils.inc
+++ b/includes/preprocess.utils.inc
@@ -33,13 +33,27 @@ function _kiso_render_region($region){
 function _kiso_has_region(?string $markup, string $allowed_tags = '') {
   $non_conditional_html_comments_pattern = '/<!--(.|\s)*?-->\s*|\r|\n/';
   $cleaned_region_output = preg_replace($non_conditional_html_comments_pattern, '', $markup);
-  return !empty(_kiso_strip_tags($cleaned_region_output, $allowed_tags));
+  return !empty(_kiso_strip_tags($cleaned_region_output));
 }
 
 /**
  * Strips html tags, except allowed, returning a trimmed clean markup.
  */
 function _kiso_strip_tags(string $markup, string $allowed_tags = '') {
-  $allowed_tags .= '<drupal-render-placeholder><img>';
-  return trim(strip_tags($markup, $allowed_tags));
+  $text = strip_tags($markup, [
+    '<drupal-render-placeholder>',
+    '<embed>',
+    '<hr>',
+    '<iframe>',
+    '<img>',
+    '<input>',
+    '<link>',
+    '<object>',
+    '<script>',
+    '<source>',
+    '<style>',
+    '<video>',
+  ]);
+  $text = twig_trim_filter($text);
+  return $text;
 }

--- a/includes/preprocess.utils.inc
+++ b/includes/preprocess.utils.inc
@@ -1,6 +1,17 @@
 <?php
 
 /**
+ * Small function to render the regions without passing them by reference.
+ * 
+ * @param $region
+ *
+ * @return mixed
+ */
+function _kiso_render_region($region){
+  return \Drupal::service('renderer')->render($region);
+}
+
+/**
  * @file
  * Utilities used by the theme preprocess functions.
  */

--- a/includes/preprocess.utils.inc
+++ b/includes/preprocess.utils.inc
@@ -1,14 +1,16 @@
 <?php
 
+use Twig\TwigFilter;
+
 /**
  * Small function to render the regions without passing them by reference.
- * 
+ *
  * @param $region
  *
  * @return mixed
  */
-function _kiso_render_region($region){
-  return \Drupal::service('renderer')->render($region);
+function _kiso_render_region($region) {
+  return Drupal::service('renderer')->render($region);
 }
 
 /**
@@ -31,9 +33,25 @@ function _kiso_render_region($region){
  * @see https://drupal.stackexchange.com/questions/175389/how-do-i-properly-detect-if-region-is-empty
  */
 function _kiso_has_region(?string $markup, string $allowed_tags = '') {
-  $non_conditional_html_comments_pattern = '/<!--(.|\s)*?-->\s*|\r|\n/';
-  $cleaned_region_output = preg_replace($non_conditional_html_comments_pattern, '', $markup);
-  return !empty(_kiso_strip_tags($cleaned_region_output));
+  $moduleHandler = Drupal::service('module_handler');
+  if ($moduleHandler->moduleExists('twig_real_content')) {
+    $filters = Drupal::service('twig_real_content.twig_extension')
+      ->getFilters();
+    $key = array_search('real_content', array_map(function(TwigFilter $filter) {
+      return $filter->getName();
+    }, $filters), TRUE);
+    $callable = $filters[$key]->getCallable();
+
+    $real_content = $callable($markup);
+
+    return !empty($real_content);
+  }
+  else {
+    $non_conditional_html_comments_pattern = '/<!--(.|\s)*?-->\s*|\r|\n/';
+    $cleaned_region_output = preg_replace($non_conditional_html_comments_pattern, '', $markup);
+
+    return !empty(_kiso_strip_tags($cleaned_region_output, $allowed_tags));
+  }
 }
 
 /**

--- a/includes/preprocess.utils.inc
+++ b/includes/preprocess.utils.inc
@@ -56,9 +56,17 @@ function _kiso_has_region(?string $markup, string $allowed_tags = '') {
 
 /**
  * Strips html tags, except allowed, returning a trimmed clean markup.
+ *
+ * @param string $markup
+ *  Original markup.
+ * @param string|array $allowed_tags
+ *  Allowed tags, can be an array of tag of a string.
+ *
+ * @return string
+ * @throws \Twig\Error\RuntimeError
  */
-function _kiso_strip_tags(string $markup, string $allowed_tags = '') {
-  $text = strip_tags($markup, [
+function _kiso_strip_tags(string $markup, string|array $allowed_tags) {
+  $allowed_tags_base = [
     '<drupal-render-placeholder>',
     '<embed>',
     '<hr>',
@@ -71,7 +79,16 @@ function _kiso_strip_tags(string $markup, string $allowed_tags = '') {
     '<source>',
     '<style>',
     '<video>',
-  ]);
+  ];
+
+  if (is_string($allowed_tags)) {
+    $allowed_tags .= implode('', $allowed_tags_base);
+  }
+  elseif (is_array($allowed_tags)) {
+    $allowed_tags = array_merge($allowed_tags_base, $allowed_tags);
+  }
+
+  $text = strip_tags($markup, $allowed_tags);
   $text = twig_trim_filter($text);
   return $text;
 }

--- a/includes/preprocess.utils.inc
+++ b/includes/preprocess.utils.inc
@@ -6,6 +6,26 @@
  */
 
 /**
+ * Properly detect if regions are empty.
+ *
+ * @param ?string $markup
+ *   The rendered region markup to be tested if empty.
+ * @param string $allowed_tags
+ *   Allowed tags to be excluded from the strip HTML tags process.
+ *
+ * @return
+ *   TRUE if the region exists and is not empty, FALSE otherwise.
+ *
+ * @see https://www.drupal.org/node/953034
+ * @see https://drupal.stackexchange.com/questions/175389/how-do-i-properly-detect-if-region-is-empty
+ */
+function _kiso_has_region(?string $markup, string $allowed_tags = '') {
+  $non_conditional_html_comments_pattern = '/<!--(.|\s)*?-->\s*|\r|\n/';
+  $cleaned_region_output = preg_replace($non_conditional_html_comments_pattern, '', $markup);
+  return !empty(_kiso_strip_tags($cleaned_region_output, $allowed_tags));
+}
+
+/**
  * Strips html tags, except allowed, returning a trimmed clean markup.
  */
 function _kiso_strip_tags(string $markup, string $allowed_tags = '') {

--- a/kiso.info.yml
+++ b/kiso.info.yml
@@ -58,7 +58,3 @@ libraries-override:
     css:
       theme:
         extlink.css: 'css/components/extlink/extlink-window.css'
-
-# Defines module dependencies
-dependencies:
-  - drupal:twig_real_content

--- a/kiso.info.yml
+++ b/kiso.info.yml
@@ -58,3 +58,7 @@ libraries-override:
     css:
       theme:
         extlink.css: 'css/components/extlink/extlink-window.css'
+
+# Defines module dependencies
+dependencies:
+  - drupal:twig_real_content

--- a/templates/layout/html.html.twig
+++ b/templates/layout/html.html.twig
@@ -27,17 +27,6 @@
     db_offline ? 'db-offline',
   ]
 %}
-{% set page_navigaton = page.navigation|render %}
-{% set page_complementary = page.complementary|render %}
-{% if page_navigation is real_content and page_complementary is real_content %}
-  {% set body_classes = body_classes|merge(['sidebar', 'two-sidebars']) %}
-{% elseif page_navigaton is real_content %}
-  {% set body_classes = body_classes|merge(['sidebar', 'one-sidebar', 'is-visible--navigation']) %}
-{% elseif page_complementary is real_content %}
-  {% set body_classes = body_classes|merge(['sidebar', 'one-sidebar', 'is-visible--complementary']) %}
-{% else %}
-  {% set body_classes = body_classes|merge(['no-sidebars']) %}
-{% endif %}
 {# Enable the "Back to top" button. #}
 {% if backtotop_enable %}
   {% set attributes = attributes.setAttribute('id', 'top') %}

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -7,7 +7,7 @@
  * can be found in the 'html.html.twig' template in this directory.
  *
  * You will find same variables as in the core 'page.html.twig' template.
- * 
+ *
  * Custom variables:
  * - has_tools, has_header, has_header_collapsible, has_highlighted, has_navigation,
  *   has_complementary, has_postscript, has_footer: Properly detect if regions are empty.
@@ -44,7 +44,7 @@
   {% block tools %}
     <div class="page__wrapper page__wrapper--tools">
       <div class="page__section page__section--tools {{ container }}">
-        {{ page.tools }}
+        {{ page_tools }}
       </div>
     </div>
   {% endblock %}
@@ -55,10 +55,10 @@
   {% block header %}
     <div class="page__wrapper page__wrapper--header">
       <header class="page__section page__section--header {{ container }}">
-        {{ page.header }}
+        {{ page_header }}
         {# This button is used as the toggle for the Header (Collapsible) #}
         <button type="button" class="button button--toggler" aria-controls="headerCollapsible" aria-expanded="false"><span>Menu</span></button>
-        {{ page.header_collapsible }}
+        {{ page_header_collapsible }}
       </header>
     </div>
   {% endblock %}
@@ -69,7 +69,7 @@
   {% block highlighted %}
     <div class="page__wrapper page__wrapper--highlighted">
       <div class="page__section page__section--highlighted {{ container }}">
-        {{ page.highlighted }}
+        {{ page_highlighted }}
       </div>
     </div>
   {% endblock %}
@@ -81,12 +81,12 @@
 
     {# Dynamic help text #}
     {% block help %}
-      {{ page.help }}
+      {{ page_help }}
     {% endblock %}
 
     {# Breadcrumb #}
     {% block breadcrumb %}
-      {{ page.breadcrumb }}
+      {{ page_breadcrumb }}
     {% endblock %}
 
     {% if has_navigation or has_complementary %}
@@ -104,7 +104,7 @@
       %}
       {% block content %}
         <main{{ content_attributes.addClass(content_classes).setAttribute('role', 'main') }}>
-          {{ page.content }}
+          {{ page_content }}
 
           {# Enable and display the "Back to top" button. #}
           {% if backtotop_enable %}
@@ -117,7 +117,7 @@
       {% if has_navigation %}
         {% block navigation %}
           <div class="page__section page__section--navigation">
-            {{ page.navigation }}
+            {{ page_navigation }}
           </div>
         {% endblock %}
       {% endif %}
@@ -126,7 +126,7 @@
       {% if has_complementary %}
         {% block complementary %}
           <div class="page__section page__section--complementary">
-            {{ page.complementary }}
+            {{ page_complementary }}
           </div>
         {% endblock %}
       {% endif %}
@@ -144,7 +144,7 @@
   {% block postscript %}
     <div class="page__wrapper page__wrapper--postscript">
       <div class="page__section page__section--postscript {{ container }}">
-        {{ page.postscript }}
+        {{ page_postscript }}
       </div>
     </div>
   {% endblock %}
@@ -155,7 +155,7 @@
   {% block footer %}
     <div class="page__wrapper page__wrapper--footer">
       <footer class="page__section page__section--footer {{ container }}">
-        {{ page.footer }}
+        {{ page_footer }}
       </footer>
     </div>
   {% endblock %}

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -7,6 +7,10 @@
  * can be found in the 'html.html.twig' template in this directory.
  *
  * You will find same variables as in the core 'page.html.twig' template.
+ * 
+ * Custom variables:
+ * - has_tools, has_header, has_header_collapsible, has_highlighted, has_navigation,
+ *   has_complementary, has_postscript, has_footer: Properly detect if regions are empty.
  *
  * Regions:
  * - page.tools: Items for the Toolbar region.
@@ -36,7 +40,7 @@
 {% set container = container_fluid ? 'container-fluid' : 'container' %}
 
 {# Toolbar Area #}
-{% if page.tools|render is real_content %}
+{% if has_tools %}
   {% block tools %}
     <div class="page__wrapper page__wrapper--tools">
       <div class="page__section page__section--tools {{ container }}">
@@ -47,7 +51,7 @@
 {% endif %}
 
 {# Banner Landmark #}
-{% if page.header|render is real_content or page.header_collapsible|render is real_content %}
+{% if has_header or has_header_collapsible %}
   {% block header %}
     <div class="page__wrapper page__wrapper--header">
       <header class="page__section page__section--header {{ container }}">
@@ -61,7 +65,7 @@
 {% endif %}
 
 {# Featured content Area #}
-{% if page.highlighted|render is real_content %}
+{% if has_highlighted %}
   {% block highlighted %}
     <div class="page__wrapper page__wrapper--highlighted">
       <div class="page__section page__section--highlighted {{ container }}">
@@ -85,7 +89,7 @@
       {{ page.breadcrumb }}
     {% endblock %}
 
-    {% if page.navigation|render is real_content or page.complementary|render is real_content %}
+    {% if has_navigation or has_complementary %}
       <div class="{{ container }}">
         <div class="row">
     {% endif %}
@@ -95,7 +99,7 @@
         set content_classes = [
           'page__section',
           'page__section--content',
-          page.navigation|render is real_content or page.complementary|render is real_content ? '' : container,
+          has_navigation or has_complementary ? '' : container,
         ]
       %}
       {% block content %}
@@ -110,7 +114,7 @@
       {% endblock %}
 
       {# Navigation sidebar (Left) #}
-      {% if page.navigation|render is real_content %}
+      {% if has_navigation %}
         {% block navigation %}
           <div class="page__section page__section--navigation">
             {{ page.navigation }}
@@ -119,7 +123,7 @@
       {% endif %}
 
       {# Related content sidebar (Right) #}
-      {% if page.complementary|render is real_content %}
+      {% if has_complementary %}
         {% block complementary %}
           <div class="page__section page__section--complementary">
             {{ page.complementary }}
@@ -127,7 +131,7 @@
         {% endblock %}
       {% endif %}
 
-    {% if page.navigation|render is real_content or page.complementary|render is real_content %}
+    {% if has_navigation or has_complementary %}
         </div>
       </div>
     {% endif %}
@@ -136,7 +140,7 @@
 {% endblock %}
 
 {# Footnotes Area #}
-{% if page.postscript|render is real_content %}
+{% if has_postscript %}
   {% block postscript %}
     <div class="page__wrapper page__wrapper--postscript">
       <div class="page__section page__section--postscript {{ container }}">
@@ -147,7 +151,7 @@
 {% endif %}
 
 {# Contentinfo Landmark #}
-{% if page.footer|render is real_content %}
+{% if has_footer %}
   {% block footer %}
     <div class="page__wrapper page__wrapper--footer">
       <footer class="page__section page__section--footer {{ container }}">


### PR DESCRIPTION
This pull request relates to [BOSA_0100-358](https://jira.hosted-tools.com/browse/BOSA_0100-358) (JIRA issue) and contains Yves's (@GyD) attempt to improve the performance of Kiso.

- The `has_{region}` functionality is kept so theme using it still can use it. Functions used to check if region is empty are kept but adapted so theme using it still can use it.
- A per region variable `page_{region}` is introduced for future themes, that variable store the rendered output of the `page.region` so it can be called in theme without re-redering the region again,
- A function `_kiso_render_region()` is introduced to avoid calling `\Drupal::service('renderer')->render($region);` each time *but* also not mark the region as rendered since the region is not passed by reference. This way if you need to alter region content after `kiso_preprocess_html()` and `kiso_preprocess_page()` it still behave as Drupal core.