### PR TITLE
Hotfix/#128: Replaced wrong `twig_trim_filter` function using `trim`

### DIFF
--- a/includes/preprocess.utils.inc
+++ b/includes/preprocess.utils.inc
@@ -89,6 +89,6 @@ function _kiso_strip_tags(string $markup, string|array $allowed_tags) {
   }
 
   $text = strip_tags($markup, $allowed_tags);
-  $text = twig_trim_filter($text);
+  $text = trim($text);
   return $text;
 }


### PR DESCRIPTION
This pull request relates to [BOSA_0100-358](https://jira.hosted-tools.com/browse/BOSA_0100-358) (JIRA issue) and **replaces the `twig_trim_filter` function using the `trim` one**. This caused unclear error reports but the `trim` function should be used instead.