### PR TITLE
fix: Update language block logic to handle <nolink> route and clean unused attributes (141)

### DIFF
--- a/includes/preprocess.links.inc
+++ b/includes/preprocess.links.inc
@@ -20,8 +20,8 @@ function kiso_preprocess_links__language_block(&$variables) {
   //    - H28: Providing definitions for abbreviations by using the abbr element.
   //  - SC 4.1.2 Name, Role, Value (Level A):
   //    - ARIA14: Using aria-label to provide an invisible label where a visible
-  //      label cannot be used 
-  // 
+  //      label cannot be used
+  //
   foreach ($variables['links'] as $langcode => &$link) {
     if ($link['link']['#url']->getRouteName() !== '<nolink>') {
       $language_name = t('@language', ['@language' => $link['text']], ['langcode' => $langcode]);
@@ -34,7 +34,10 @@ function kiso_preprocess_links__language_block(&$variables) {
       $link['text_attributes']['lang'] = $langcode;
       $link['text_attributes']['aria-label'] = $link['title'];
       $link['text'] = strtoupper($langcode);
-      unset($link['attributes']['data-drupal-link-system-path']);
+      // Remove the link to maintain compatibility with existing Twig templates.
+      // Also, remove the 'data-drupal-link-system-path' attribute to prevent
+      // misinterpretation when the route is '<nolink>'.
+      unset($link['link'], $link['attributes']['data-drupal-link-system-path']);
     }
   }
 }

--- a/includes/preprocess.links.inc
+++ b/includes/preprocess.links.inc
@@ -23,7 +23,7 @@ function kiso_preprocess_links__language_block(&$variables) {
   //      label cannot be used 
   // 
   foreach ($variables['links'] as $langcode => &$link) {
-    if (isset($link['link'])) {
+    if ($link['link']['#url']->getRouteName() !== '<nolink>') {
       $language_name = t('@language', ['@language' => $link['text']], ['langcode' => $langcode]);
       $link['link']['#options']['attributes']['lang'] = $langcode;
       $link['link']['#options']['attributes']['aria-label'] = $language_name;
@@ -34,6 +34,7 @@ function kiso_preprocess_links__language_block(&$variables) {
       $link['text_attributes']['lang'] = $langcode;
       $link['text_attributes']['aria-label'] = $link['title'];
       $link['text'] = strtoupper($langcode);
+      unset($link['attributes']['data-drupal-link-system-path']);
     }
   }
 }

--- a/templates/navigation/links--language-block.html.twig
+++ b/templates/navigation/links--language-block.html.twig
@@ -21,7 +21,7 @@
   <ul{{ attributes.addClass('links--language-block') }}>
     {%- for item in links -%}
       <li{{ item.attributes.removeAttribute('hreflang') }}>
-        {%- if item.link -%}
+        {% if item.link['#url'].routeName != '<nolink>' %}
           {{ item.link }}
         {%- elseif item.text_attributes -%}
           <del{{ item.text_attributes }}>

--- a/templates/navigation/links--language-block.html.twig
+++ b/templates/navigation/links--language-block.html.twig
@@ -21,7 +21,7 @@
   <ul{{ attributes.addClass('links--language-block') }}>
     {%- for item in links -%}
       <li{{ item.attributes.removeAttribute('hreflang') }}>
-        {% if item.link['#url'].routeName != '<nolink>' %}
+        {%- if item.link -%}
           {{ item.link }}
         {%- elseif item.text_attributes -%}
           <del{{ item.text_attributes }}>


### PR DESCRIPTION
BREAKING CHANGE: All clients that have a template override must update the links--language-block.html.twig